### PR TITLE
Refactor IndexReader to LuceneIndexReader

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ pyserini==1.2.0
 torch>=2.2.2
 tqdm>=4.66.2
 transformers>=4.40.1
-retry

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyserini==1.2.0
 torch>=2.2.2
 tqdm>=4.66.2
 transformers>=4.40.1
+retry

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 datasets>=2.19.0
 fschat>=0.2.36
 openai>=1.24.1
-pyserini>=0.35.0
+pyserini==1.2.0
 torch>=2.2.2
 tqdm>=4.66.2
 transformers>=4.40.1

--- a/src/umbrela/utils/qrel_utils.py
+++ b/src/umbrela/utils/qrel_utils.py
@@ -6,7 +6,11 @@ import re
 import platform
 import subprocess
 
-from pyserini.index.lucene import LuceneIndexReader
+try:
+    from pyserini.index.lucene import LuceneIndexReader
+except ImportError:
+    print("\nPyserini version is likely too old, check and ensure pyserini >= 0.1.2.0\n")
+    
 from pyserini.search import get_qrels_file, get_topics
 
 

--- a/src/umbrela/utils/qrel_utils.py
+++ b/src/umbrela/utils/qrel_utils.py
@@ -6,7 +6,7 @@ import re
 import platform
 import subprocess
 
-from pyserini.index.lucene import IndexReader
+from pyserini.index.lucene import LuceneIndexReader
 from pyserini.search import get_qrels_file, get_topics
 
 
@@ -134,7 +134,7 @@ def get_qrels(qrel_info):
 def get_index_reader(qrel):
     # Index reader
     if qrel in ["dl19-passage", "dl20-passage"]:
-        index_reader = IndexReader.from_prebuilt_index("msmarco-v1-passage")
+        index_reader = LuceneIndexReader.from_prebuilt_index("msmarco-v1-passage")
     else:
         index_reader = None
     return index_reader


### PR DESCRIPTION
Fixes the `ImportError: cannot import name 'IndexReader' from 'pyserini.index.lucene'` issue by refactoring `IndexReader` to `LuceneIndexReader`. 

This change is seen in Pyserini issue #2093, which can be found at: https://github.com/castorini/pyserini/issues/2093.

Full error message this PR solves for reference:
```
WARNING: Using incubator modules: jdk.incubator.vector
Traceback (most recent call last):
  File "/home/ssubr/RESEARCH/forks/umbrela/src/umbrela/gpt_judge.py", line 11, in <module>
    from umbrela.llm_judge import LLMJudge
  File "/home/ssubr/miniconda3/envs/umbrela/lib/python3.10/site-packages/umbrela/llm_judge.py", line 3, in <module>
    from umbrela.utils import qrel_utils
  File "/home/ssubr/miniconda3/envs/umbrela/lib/python3.10/site-packages/umbrela/utils/qrel_utils.py", line 4, in <module>
    from pyserini.index.lucene import IndexReader
ImportError: cannot import name 'IndexReader' from 'pyserini.index.lucene' (/home/ssubr/miniconda3/en
```