### PR TITLE
Add retry to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ pyserini==1.2.0
 torch>=2.2.2
 tqdm>=4.66.2
 transformers>=4.40.1
-retry

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyserini==1.2.0
 torch>=2.2.2
 tqdm>=4.66.2
 transformers>=4.40.1
+retry

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 datasets>=2.19.0
 fschat>=0.2.36
 openai>=1.24.1
-pyserini>=0.35.0
+pyserini==1.2.0
 torch>=2.2.2
 tqdm>=4.66.2
 transformers>=4.40.1

--- a/src/umbrela/utils/qrel_utils.py
+++ b/src/umbrela/utils/qrel_utils.py
@@ -6,7 +6,7 @@ import re
 import platform
 import subprocess
 
-from pyserini.index.lucene import IndexReader
+from pyserini.index.lucene import LuceneIndexReader
 from pyserini.search import get_qrels_file, get_topics
 
 
@@ -134,7 +134,7 @@ def get_qrels(qrel_info):
 def get_index_reader(qrel):
     # Index reader
     if qrel in ["dl19-passage", "dl20-passage"]:
-        index_reader = IndexReader.from_prebuilt_index("msmarco-v1-passage")
+        index_reader = LuceneIndexReader.from_prebuilt_index("msmarco-v1-passage")
     else:
         index_reader = None
     return index_reader


### PR DESCRIPTION
Adding Retry to `requirements.txt` because eval would not work. You would have to separately running `pip install retry`. Hence, this also improves reproducibility.

Actually, `matplotlib` should also be added for the same reason, but I have left it out since I noticed it has added it in another open PR. 