### PR TITLE
Add retry to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyserini>=0.35.0
 torch>=2.2.2
 tqdm>=4.66.2
 transformers>=4.40.1
+retry


### PR DESCRIPTION
Adding retry to `requirements.txt` because without separately running `pip install retry` eval will not work. As such, this also improves reproducibility.

Actually, `matplotlib` should also be added for the same reason, but I have left it out since I noticed it has added it in another open PR.