### PR TITLE
Add async-first GPT judge support

### DIFF
--- a/src/umbrela/gpt_judge.py
+++ b/src/umbrela/gpt_judge.py
@@ -1,12 +1,10 @@
 import argparse
+import asyncio
 import os
+
 from typing_extensions import Optional
 
 from dotenv import load_dotenv
-import openai
-from openai import AzureOpenAI, OpenAI
-from retry import retry
-from tqdm import tqdm
 
 from umbrela.llm_judge import LLMJudge
 from umbrela.utils import common_utils
@@ -24,15 +22,27 @@ class GPTJudge(LLMJudge):
         prompt_type: Optional[str] = "bing",
         few_shot_count: int = 0,
         use_azure_openai: bool = False,
+        max_concurrency: int = 8,
     ) -> None:
         super().__init__(qrel, model_name, prompt_file, prompt_type, few_shot_count)
+        self.max_concurrency = max_concurrency
         self.create_openai_client(use_azure_openai=use_azure_openai)
 
     def create_openai_client(self, use_azure_openai: bool = False):
+        try:
+            import openai
+            from openai import AsyncAzureOpenAI, AsyncOpenAI
+        except ImportError as exc:
+            raise ImportError(
+                "GPTJudge requires the OpenAI SDK. Install umbrela with "
+                "`uv sync --extra cloud`."
+            ) from exc
+
         openai_api_key = os.getenv("OPENAI_API_KEY") or os.getenv("OPEN_AI_API_KEY")
         azure_api_key = os.getenv("AZURE_OPENAI_API_KEY") or openai_api_key
         api_version = os.getenv("AZURE_OPENAI_API_VERSION")
         azure_endpoint = os.getenv("AZURE_OPENAI_API_BASE")
+        self._bad_request_error = openai.BadRequestError
 
         if use_azure_openai:
             if not all([azure_api_key, azure_endpoint, api_version]):
@@ -42,7 +52,7 @@ class GPTJudge(LLMJudge):
                     "`AZURE_OPENAI_API_VERSION`, and "
                     "`AZURE_OPENAI_API_KEY` (or `OPENAI_API_KEY` as fallback)."
                 )
-            self.client = AzureOpenAI(
+            self.async_client = AsyncAzureOpenAI(
                 api_key=azure_api_key,
                 api_version=api_version,
                 azure_endpoint=azure_endpoint,
@@ -52,35 +62,60 @@ class GPTJudge(LLMJudge):
         else:
             if openai_api_key is None:
                 raise KeyError("OPENAI_API_KEY")
-            self.client = OpenAI(api_key=openai_api_key)
+            self.async_client = AsyncOpenAI(api_key=openai_api_key)
             self.engine = self.model_name
             self.use_azure_ai = False
 
-    @retry(tries=3, delay=0.1)
-    def run_gpt(self, prompt, max_new_tokens):
+    async def run_gpt(self, prompt, max_new_tokens):
         messages = [
             {"role": "system", "content": "You are a helpful assistant."},
             {"role": "user", "content": prompt},
         ]
-        try:
-            response = self.client.chat.completions.create(
-                model=self.engine,
-                messages=messages,
-                max_tokens=max_new_tokens,
-                temperature=0,
-                top_p=1,
-                frequency_penalty=0.5,
-                presence_penalty=0,
-            )
-            output = (
-                response.choices[0].message.content.lower()
-                if response.choices[0].message.content
-                else ""
-            )
-        except openai.BadRequestError as e:
-            print(f"Encountered {e} for {prompt}")
-            output = ""
-        return output
+        for attempt in range(3):
+            try:
+                response = await self.async_client.chat.completions.create(
+                    model=self.engine,
+                    messages=messages,
+                    max_tokens=max_new_tokens,
+                    temperature=0,
+                    top_p=1,
+                    frequency_penalty=0.5,
+                    presence_penalty=0,
+                )
+                return (
+                    response.choices[0].message.content.lower()
+                    if response.choices[0].message.content
+                    else ""
+                )
+            except self._bad_request_error as e:
+                print(f"Encountered {e} for {prompt}")
+                return ""
+            except Exception:
+                if attempt == 2:
+                    raise
+                await asyncio.sleep(0.1)
+
+        return ""
+
+    async def async_predict_with_llm(
+        self,
+        request_dict: list,
+        max_new_tokens: int,
+        prepocess: bool,
+    ):
+        _, prompts = self.prepare_request_inputs(request_dict, prepocess)
+        semaphore = asyncio.Semaphore(self.max_concurrency)
+
+        async def run_prompt(prompt: str) -> str:
+            async with semaphore:
+                return await self.run_gpt(prompt, max_new_tokens)
+
+        return await asyncio.gather(*(run_prompt(prompt) for prompt in prompts))
+
+    def judge(self, request_dict, max_new_tokens=100, prepocess: bool = True):
+        return common_utils.run_async_blocking(
+            self.async_judge(request_dict, max_new_tokens, prepocess)
+        )
 
     def predict_with_llm(
         self,
@@ -88,24 +123,17 @@ class GPTJudge(LLMJudge):
         max_new_tokens: int,
         prepocess: bool,
     ):
-        if prepocess:
-            self.query_passage = common_utils.preprocess_request_dict(request_dict)
-        else:
-            self.query_passage = request_dict
-        self.prompts = common_utils.generate_prompts(
-            self.query_passage, self.prompt_examples, self._prompt_template
+        return common_utils.run_async_blocking(
+            self.async_predict_with_llm(request_dict, max_new_tokens, prepocess)
         )
 
-        outputs = [
-            self.run_gpt(prompt, max_new_tokens) for prompt in tqdm(self.prompts)
-        ]
-        return outputs
-
-    def judge(self, request_dict, max_new_tokens=100, prepocess: bool = True):
-        outputs = self.predict_with_llm(request_dict, max_new_tokens, prepocess)
-        return common_utils.prepare_judgments(
-            outputs, self.query_passage, self.prompts, self.model_name
+    async def async_judge(
+        self, request_dict, max_new_tokens=100, prepocess: bool = True
+    ):
+        outputs = await self.async_predict_with_llm(
+            request_dict, max_new_tokens, prepocess
         )
+        return self.prepare_judgments(outputs)
 
 
 def main():
@@ -127,6 +155,12 @@ def main():
         action="store_true",
         help="Use Azure OpenAI instead of the default public OpenAI API.",
     )
+    parser.add_argument(
+        "--max_concurrency",
+        type=int,
+        default=8,
+        help="Maximum number of concurrent OpenAI requests.",
+    )
 
     args = parser.parse_args()
     load_dotenv()
@@ -138,6 +172,7 @@ def main():
         args.prompt_type,
         args.few_shot_count,
         use_azure_openai=args.use_azure_openai,
+        max_concurrency=args.max_concurrency,
     )
     judge.evalute_results_with_qrel(
         args.result_file,

--- a/src/umbrela/llm_judge.py
+++ b/src/umbrela/llm_judge.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+import asyncio
 from importlib import resources
 import os
 import statistics
@@ -65,13 +66,42 @@ class LLMJudge(ABC):
     def display_prompt_template(self):
         print(self._prompt_template)
 
+    def prepare_request_inputs(self, request_dict, prepocess):
+        query_passage, prompts = common_utils.prepare_request_inputs(
+            request_dict,
+            prepocess,
+            self.prompt_examples,
+            self._prompt_template,
+        )
+        self.query_passage = query_passage
+        self.prompts = prompts
+        return query_passage, prompts
+
+    def prepare_judgments(self, outputs):
+        return common_utils.prepare_judgments(
+            outputs, self.query_passage, self.prompts, self.model_name
+        )
+
     @abstractmethod
     def predict_with_llm(self, request_dict, max_new_tokens, prepocess):
         pass
 
+    async def async_predict_with_llm(self, request_dict, max_new_tokens, prepocess):
+        return await asyncio.to_thread(
+            self.predict_with_llm, request_dict, max_new_tokens, prepocess
+        )
+
     @abstractmethod
     def judge(self, request_dict, max_new_tokens=100, prepocess: bool = True):
         pass
+
+    async def async_judge(
+        self, request_dict, max_new_tokens=100, prepocess: bool = True
+    ):
+        outputs = await self.async_predict_with_llm(
+            request_dict, max_new_tokens, prepocess
+        )
+        return self.prepare_judgments(outputs)
 
     def calculate_kappa(self, gts, preds):
         print(f"Kohen kappa overall: {cohen_kappa_score(gts, preds)}")

--- a/src/umbrela/utils/common_utils.py
+++ b/src/umbrela/utils/common_utils.py
@@ -1,8 +1,13 @@
-import re
+import asyncio
 import os
+import re
+import threading
+from typing import Awaitable, TypeVar
 
 import matplotlib.pyplot as plt
 from sklearn.metrics import cohen_kappa_score, confusion_matrix, ConfusionMatrixDisplay
+
+T = TypeVar("T")
 
 
 def preprocess_request_dict(request_dict):
@@ -23,6 +28,40 @@ def generate_prompts(query_passage, prompt_examples, prompt_template):
         )
         prompts.append(prompt)
     return prompts
+
+
+def prepare_request_inputs(request_dict, preprocess, prompt_examples, prompt_template):
+    if preprocess:
+        query_passage = preprocess_request_dict(request_dict)
+    else:
+        query_passage = request_dict
+    prompts = generate_prompts(query_passage, prompt_examples, prompt_template)
+    return query_passage, prompts
+
+
+def run_async_blocking(coro: Awaitable[T]) -> T:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    result: dict[str, T] = {}
+    error: dict[str, BaseException] = {}
+
+    def runner() -> None:
+        try:
+            result["value"] = asyncio.run(coro)
+        except BaseException as exc:
+            error["error"] = exc
+
+    thread = threading.Thread(target=runner, daemon=True)
+    thread.start()
+    thread.join()
+
+    if "error" in error:
+        raise error["error"]
+
+    return result["value"]
 
 
 def parse_fewshot_response(response: str, passage: str, query: str) -> int:

--- a/tests/test_gpt_judge_async.py
+++ b/tests/test_gpt_judge_async.py
@@ -1,0 +1,85 @@
+import asyncio
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from umbrela.gpt_judge import GPTJudge
+
+
+SAMPLE_REQUEST = {
+    "query": {"text": "how long is life cycle of flea", "qid": "264014"},
+    "candidates": [
+        {"doc": {"segment": "first passage"}, "docid": "d1"},
+        {"doc": {"segment": "second passage"}, "docid": "d2"},
+        {"doc": {"segment": "third passage"}, "docid": "d3"},
+    ],
+}
+
+
+class GPTJudgeAsyncTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.prompt_file = tempfile.NamedTemporaryFile("w", delete=False)
+        self.prompt_file.write("{examples}\nQuery: {query}\nPassage: {passage}\n")
+        self.prompt_file.flush()
+        self.addCleanup(self.prompt_file.close)
+        self.addCleanup(lambda: os.unlink(self.prompt_file.name))
+
+    def make_judge(self) -> GPTJudge:
+        def fake_create_openai_client(self, use_azure_openai: bool = False) -> None:
+            self.async_client = object()
+            self.engine = self.model_name
+            self.use_azure_ai = use_azure_openai
+
+        with patch.object(GPTJudge, "create_openai_client", fake_create_openai_client):
+            return GPTJudge(
+                qrel="dl19-passage",
+                model_name="gpt-4o",
+                prompt_file=self.prompt_file.name,
+                prompt_type=None,
+                few_shot_count=0,
+                max_concurrency=2,
+            )
+
+    def test_async_judge_preserves_input_order(self) -> None:
+        judge = self.make_judge()
+
+        async def fake_run_gpt(prompt: str, max_new_tokens: int) -> str:
+            if "first passage" in prompt:
+                await asyncio.sleep(0.03)
+                return "2"
+            if "second passage" in prompt:
+                await asyncio.sleep(0.01)
+                return "1"
+            await asyncio.sleep(0.02)
+            return "3"
+
+        judge.run_gpt = fake_run_gpt  # type: ignore[method-assign]
+        judgments = asyncio.run(judge.async_judge(SAMPLE_REQUEST))
+
+        self.assertEqual([item["passage"] for item in judgments], [
+            "first passage",
+            "second passage",
+            "third passage",
+        ])
+        self.assertEqual([item["judgment"] for item in judgments], [2, 1, 3])
+        self.assertTrue(all("result_status" in item for item in judgments))
+
+    def test_sync_judge_uses_async_path(self) -> None:
+        judge = self.make_judge()
+
+        async def fake_async_predict_with_llm(
+            request_dict, max_new_tokens: int, prepocess: bool
+        ):
+            judge.prepare_request_inputs(request_dict, prepocess)
+            return ["0", "1", "2"]
+
+        judge.async_predict_with_llm = fake_async_predict_with_llm  # type: ignore[method-assign]
+        judgments = judge.judge(SAMPLE_REQUEST)
+
+        self.assertEqual([item["judgment"] for item in judgments], [0, 1, 2])
+        self.assertEqual(judgments[1]["passage"], "second passage")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add async-first OpenAI and Azure OpenAI support to GPTJudge
- keep synchronous judge and predict methods as compatibility wrappers
- add regression tests for async ordering and sync wrapper behavior

## Verification
- uv run python -m unittest tests/test_gpt_judge_async.py
- uv run umbrela-gpt --help
- uv run python -m compileall src examples tests